### PR TITLE
turn off auto_scale, so that scale_factor is properly propagated

### DIFF
--- a/ocean_remap.py
+++ b/ocean_remap.py
@@ -429,6 +429,7 @@ def main():
     # field_names = ('HT', 'REGION_MASK')
 
     fptr_in = nc.Dataset(testfile_in_fname, 'r') # pylint: disable=E1101
+    fptr_in.set_auto_scale(False)
     fptr_out = nc.Dataset(testfile_out_fname, 'w') # pylint: disable=E1101
 
     copy_time(fptr_in, fptr_out)
@@ -443,6 +444,7 @@ def main():
         print(field_name)
 
         varid_out = def_var(field_name, fptr_in, fptr_out, dim_names_partial, dim_names_full)
+        varid_out.set_auto_scale(False)
 
         # use appropriate matrix for regridding
         if dim_names_full['depth'] in varid_out.dimensions:


### PR DESCRIPTION
If the example code of `ocean_remap.py` is applied to POP output with the `scale_factor` attribute, then values in the remapped output where there is land are not set to `_FillValue`, but to a scaled version of `_FillValue`. This PR turns off netCDF4's `auto_scale` in the `ocean_remap.py` example code, so that `scale_factor` is properly propagated through.